### PR TITLE
fix: update the default  LA cap limit

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -109,7 +109,7 @@ variable "retention_in_days" {
 
 variable "daily_quota_gb" {
   type        = string
-  default     = "-1"
+  default     = "1"
   description = "The workspace daily quota for ingestion in GB. Set to -1 for unlimited ingestion."
 }
 


### PR DESCRIPTION
## Description

<!--
🎉 Thank you for your contribution!

Please provide a brief summary of the changes in this pull request, including:
- fix the default value of Log analytical workspace daily data ingestion capacity to 1 GB.
- To prevent the cost 
-->

Fixes # 

Closes # 

---

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Feature
- [ ] Feature (Breaking Change)
- [x] Fix
- [ ] Fix (Breaking Change)
- [ ] CI/CD
- [ ] Documentation
- [ ] Other (please specify):

---

## Checklist

- [x] I have reviewed open pull requests to avoid duplication of work
- [ ] All relevant pipelines or checks pass successfully
- [x] I have added or updated documentation if applicable
